### PR TITLE
This is intial POC to show the following

### DIFF
--- a/include/dbus_interface.hpp
+++ b/include/dbus_interface.hpp
@@ -1,0 +1,164 @@
+#pragma once
+#include "logging.h"
+
+#include <app.h>
+
+#include <boost/container/flat_map.hpp>
+#include <sdbusplus/bus/match.hpp>
+#include <sdbusplus/message/types.hpp>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace redfish
+{
+
+using GetManagedPropertyType = boost::container::flat_map<
+    std::string, std::variant<std::string, bool, uint8_t, int16_t, uint16_t,
+                              int32_t, uint32_t, int64_t, uint64_t, double>>;
+
+using GetManagedObjectsType = boost::container::flat_map<
+    sdbusplus::message::object_path,
+    boost::container::flat_map<std::string, GetManagedPropertyType>>;
+
+class DbusInterface
+{
+
+  private:
+   // multimap is required as we need to create a match for 
+   // interface added and interface removed on the same object.
+
+    std::multimap<std::string, std::unique_ptr<sdbusplus::bus::match_t>>
+        objectMap;
+
+  public:
+    template <typename MessageHandler, typename PropertyHandler,
+              typename... InputArgs>
+    void getDbusObject(MessageHandler&& handler, PropertyHandler&& propHandler,
+                       const std::string& service, const std::string& objpath,
+                       const std::string& interface, const std::string& method,
+                       const InputArgs&... a)
+    {
+        if (interface == "xyz.openbmc_project.ObjectMapper" &&
+            method == "GetObject")
+        {
+            crow::connections::systemBus->async_method_call(
+                [this, objpath, handler,
+                 propHandler](const boost::system::error_code ec,
+                              const ManagedObjectType& ldapObjects) {
+                    if (!ec)
+                    {
+                        std::string propMatchString =
+                            ("type='signal',"
+                             "interface='org.freedesktop.DBus.Properties',"
+                             "path_namespace='" +
+                             objpath +
+                             "',"
+                             "member='PropertiesChanged'");
+                        objectMap.emplace(
+                            objpath,
+                            std::make_unique<sdbusplus::bus::match::match>(
+                                *crow::connections::systemBus, propMatchString,
+                                propHandler, nullptr));
+                        BMCWEB_LOG_DEBUG
+                            << "********Printing Monitor Map**************";
+                        for (auto object : objectMap)
+                        {
+                            BMCWEB_LOG_DEBUG << object.first;
+                        }
+                        BMCWEB_LOG_DEBUG
+                            << "********Printing done**************";
+
+                        handler(ec, ldapObjects);
+                    }
+                },
+                service, objpath, interface, method, a...);
+        }
+    }
+
+    template <typename MessageHandler, typename ObjectHandler,
+              typename... InputArgs>
+    void getAllDbusObjects(MessageHandler&& handler,
+                           ObjectHandler&& notifyObjHandler,
+                           const std::string& service,
+                           const std::string& objpath,
+                           const std::string& interface,
+                           const std::string& method, const InputArgs&... a)
+    {
+        if (interface == "org.freedesktop.DBus.ObjectManager" &&
+            method == "GetManagedObjects")
+        {
+            crow::connections::systemBus->async_method_call(
+                [this, objpath, handler,
+                 notifyObjHandler](const boost::system::error_code ec,
+                                   const GetManagedObjectsType& objects) {
+                    // Add the interface added/removed match for the objects
+                    // under this.
+                    if (!ec)
+                    {
+                        std::string objMatchString =
+                            ("type='signal',"
+                             "interface='org.freedesktop.DBus.ObjectManager',"
+                             "path_namespace='" +
+                             objpath +
+                             "',"
+                             "member='InterfacesAdded'");
+                        BMCWEB_LOG_DEBUG << "Creating match " << objMatchString;
+                        objectMap.emplace(std::make_pair(
+                            objpath,
+                            std::make_unique<sdbusplus::bus::match::match>(
+                                *crow::connections::systemBus, objMatchString,
+                                notifyObjHandler, nullptr)));
+                        objMatchString =
+                            ("type='signal',"
+                             "interface='org.freedesktop.DBus.ObjectManager',"
+                             "path_namespace='" +
+                             objpath +
+                             "',"
+                             "member='InterfacesRemoved'");
+                        BMCWEB_LOG_DEBUG << "Creating match " << objMatchString;
+                        objectMap.emplace(std::make_pair(
+                            objpath,
+                            std::make_unique<sdbusplus::bus::match::match>(
+                                *crow::connections::systemBus, objMatchString,
+                                notifyObjHandler, nullptr)));
+                        // Add the property handler match for  all the objects.
+                        for (auto& object : objects)
+                        {
+                            std::string propMatchString =
+                                ("type='signal',"
+                                 "interface='org.freedesktop.DBus.Properties',"
+                                 "path_namespace='" +
+                                 object.first.str +
+                                 "',"
+                                 "member='PropertiesChanged'");
+                            objectMap.emplace(
+                                object.first,
+                                std::make_unique<sdbusplus::bus::match::match>(
+                                    *crow::connections::systemBus,
+                                    propMatchString, notifyObjHandler,
+                                    nullptr));
+                            BMCWEB_LOG_DEBUG << "Creating match "
+                                             << propMatchString;
+                        }
+                        BMCWEB_LOG_DEBUG
+                            << "********Printing Monitor Map**************";
+                        for (auto& object : objectMap)
+                        {
+                            BMCWEB_LOG_DEBUG << object.first;
+                        }
+                        BMCWEB_LOG_DEBUG
+                            << "********Printing done**************";
+
+                        handler(ec, objects);
+                    }
+                },
+                service, objpath, interface, method, a...);
+        }
+    }
+           
+
+};
+
+} // namespace redfish


### PR DESCRIPTION
   -> How we can cache the properties?
   -> How the cache properties can be updated?

This POC is to get a feed back on the caching approach?

Are we on right direction or should we change the
direction?

- Create the Dbusinterface class which is the interface
class to invoke the Dbus opertiaon, The idea is to
create the new function in the class for the opertaion like
GetMangedObjects,GetSubtreepaths. which internaly creates the
match object(properties changed) for all the managed objects
or under the given root and ceates the match for interface added/
interface removed.

Once match gets hit the call back is called(notiFy handler) for the
object.

-Create the data interface class which is to keep all the raw data
for the logentry(Bmcdump, SystemDump).

- Data interface class uses the DbusInterface class for getting all the
  manageed objects.

- Callback gets called when there is any update on the Dbus object to update the
   cached properties
   -> Interface added/ removed/ Properties changed.

- What needs to be done->
   -  Update the map in the DbusInterface class when there is a user initiated
     delete action.
   - certian code is commented which needs to be corrected.

The aim was to get the feedback about the approach.

Signed-off-by: Ratan Gupta <ratagupt@linux.vnet.ibm.com>