### PR TITLE
systems.hpp - initial multi-host implementation

### DIFF
--- a/scripts/test-all-routes.sh
+++ b/scripts/test-all-routes.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+if [[ -z $1 ]]; then
+    echo "ERR specify filename to store response"
+else
+
+    file=$1
+
+    echo "GET /redfish/v1/Systems" > $file
+    echo "" >> $file
+    curl -k 'https://127.0.0.1:4343/redfish/v1/Systems' \
+        -H 'X-Auth-Token: '"$token"'' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "GET /redfish/v1/Systems/system" >> $file
+    echo "" >> $file
+    curl -k 'https://127.0.0.1:4343/redfish/v1/Systems/system' \
+        -H 'X-Auth-Token: '"$token"'' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "GET /redfish/v1/Systems/system0" >> $file
+    echo "" >> $file
+    curl -k 'https://127.0.0.1:4343/redfish/v1/Systems/system0' \
+        -H 'X-Auth-Token: '"$token"'' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "GET /redfish/v1/Systems/system1" >> $file
+    echo "" >> $file
+    curl -k 'https://127.0.0.1:4343/redfish/v1/Systems/system1' \
+        -H 'X-Auth-Token: '"$token"'' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "GET /redfish/v/fileSystems/sysem0" >> $1
+    echo "" >> $file
+    curl -k 'https://127.0.0.1:4343/redfish/v1/Systems/sysem0' \
+        -H 'X-Auth-Token: '"$token"'' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "GET /redfish/v1/Systems/foobar" >> $file
+    echo "" >> $file
+    echo "" >> $file
+    curl -k 'https://127.0.0.1:4343/redfish/v1/Systems/foobar' \
+        -H 'X-Auth-Token: '"$token"'' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "GET /redfish/v1/Systems/system/ResetActionInfo" >> $file
+    echo "" >> $file
+    curl -k 'https://127.0.0.1:4343/redfish/v1/Systems/system/ResetActionInfo' \
+        -H 'X-Auth-Token: '"$token"'' >> $file
+    echo "#####################################################################" >> $file
+
+    echo "GET /redfish/v1/Systems/system0/ResetActionInfo" >> $file
+    echo "" >> $file
+    curl -k 'https://127.0.0.1:4343/redfish/v1/Systems/system0/ResetActionInfo' \
+        -H 'X-Auth-Token: '"$token"'' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "GET /redfish/v1/Systems/system1/ResetActionInfo" >> $file
+    echo "" >> $file
+    curl -k 'https://127.0.0.1:4343/redfish/v1/Systems/system1/ResetActionInfo' \
+        -H 'X-Auth-Token: '"$token"'' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "GET /redfish/v1/Systems/sysem0/ResetActionInfo" >> $file
+    echo "" >> $file
+    curl -k 'https://127.0.0.1:4343/redfish/v1/Systems/sysem0/ResetActionInfo' \
+        -H 'X-Auth-Token: '"$token"'' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "GET /redfish/v1/Systems/foobar/ResetActionInfo" >> $file
+    echo "" >> $file
+    curl -k 'https://127.0.0.1:4343/redfish/v1/Systems/foobar/ResetActionInfo' \
+        -H 'X-Auth-Token: '"$token"'' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "POST /redfish/v1/Systems/system/Actions/ComputerSystem.Reset" >> $file
+    echo "" >> $file
+    curl -k -X POST 'https://127.0.0.1:4343/redfish/v1/Systems/system/Actions/ComputerSystem.Reset' \
+    -H "Content-Type: application/json" -H 'X-Auth-Token: '"$token"'' \
+    -d '{ "ResetType": "GracefulRestart" }' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "POST /redfish/v1/Systems/system0/Actions/ComputerSystem.Reset" >> $file
+    echo "" >> $file
+    curl -k -X POST 'https://127.0.0.1:4343/redfish/v1/Systems/system0/Actions/ComputerSystem.Reset' \
+    -H "Content-Type: application/json" -H 'X-Auth-Token: '"$token"'' \
+    -d '{ "ResetType": "GracefulRestart" }' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "POST /redfish/v1/Systems/system1/Actions/ComputerSystem.Reset" >> $file
+    echo "" >> $file
+    curl -k -X POST 'https://127.0.0.1:4343/redfish/v1/Systems/system1/Actions/ComputerSystem.Reset' \
+    -H "Content-Type: application/json" -H 'X-Auth-Token: '"$token"'' \
+    -d '{ "ResetType": "GracefulRestart" }' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+
+    echo "POST /redfish/v1/Systems/sysem0/Actions/ComputerSystem.Reset" >> $file
+    echo "" >> $file
+    curl -k -X POST 'https://127.0.0.1:4343/redfish/v1/Systems/sysem0/Actions/ComputerSystem.Reset' \
+    -H "Content-Type: application/json" -H 'X-Auth-Token: '"$token"'' \
+    -d '{ "ResetType": "GracefulRestart" }' >> $file
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+
+    echo "" >> $file
+    echo "POST /redfish/v1/Systems/foobar/Actions/ComputerSystem.Reset" >> $file
+    echo "" >> $file
+
+    curl -k -X POST 'https://127.0.0.1:4343/redfish/v1/Systems/foobar/Actions/ComputerSystem.Reset' \
+    -H "Content-Type: application/json" -H 'X-Auth-Token: '"$token"'' \
+    -d '{ "ResetType": "GracefulRestart" }' >> $file
+
+    echo "" >> $file
+    echo "#####################################################################" >> $file
+    echo "" >> $file
+fi


### PR DESCRIPTION
# BMCWEB multi-host implementation

In order to support class 1 multi-host server configurations (i.e. yosemite v3, 1 BMC, N hosts), this change enables bmcweb to gather information on multiple available hosts and handle the information accordingly.
The implementation is based on an already taken - and now abondened - effort from earlier this year as can be seen on [gerrit](https://gerrit.openbmc.org/c/openbmc/bmcweb/+/52075):

> The redfish core library api has only support for bmc system with
> single host/computer system. The platforms with multiple hosts cannot
> be discovered and computer system specific redfish queries is not
> supported with the current implementation.
>
> This change adds initial support to discover and populate multihost
> systems as well as single host systems and support some system info
> queries. The host systems discovery is based on number of host power
> state instances.(xyz.openbmc_project.State.Host).
>
> The multi-host computer system discovery is placed under meson option
> "unstable-redfish-multi-computer-system". by default this is option
> is disabled.In this case existing single host computer system
> discovery implementation is unaffected.
>
> The redfish url for single host system is represented by the name
> "system".
>
> i.e : /redfish/v1/Systems/system
>
> The multi host system uses the same name with host number at the end.
>
> /redfish/v1/Systems/system1
> /redfish/v1/Systems/system2
> .
> .
> /redfish/v1/Systems/systemN
>
> The change expects no impact on current single host implementation.
> It only extends the support for multihost bmc systems.

The current changes are only a subset of the patches to come, to fully implement multi host support.

## Testing
NOTE: real hardware testing hasn't been performed yet!
Changes were tested in QEMU with the romulus image by IBM. After successful compilation of bmcweb on local machine,
the resulting patch file has been appended to the yocto build system in ```meta-ibm/meta-romulus/recipes-phosphor/interfaces/bmcweb```.

In general,  all Redfish routes touched by the change need to be tested - for both - single-host- and multi-host-configuration to ensure that we don't break the single-host configuration. In order to automate this process to some extend, 
the ```scripts/test-all-routes.sh``` curls every route for you, and stores the response in a file that you have to specify as argument
to the script.  Afterwards you have to compare the response to the expected output:

### Expected response

<details>
  <summary>Expected response single host</summary>

    - GET /redfish/v1/Systems
      Response should contain one system called "system"
    - GET /redfish/v1/Systems/system
      Response should contain all information for system called "system"
    - GET /redfish/v1/Systems/system0
      Response should contain all information for system called "system"
    - GET /redfish/v1/Systems/system1
      Should return 404 resource not found error
    - GET /redfish/v1/Systems/foobar
      Should return 404 resource not found error
    - GET /redfish/v1/Systems/sysem0
      Should return 404 resource not found error

    - GET /redfish/v1/Systems/system/ResetActionInfo
      Response should contain all ResetAction information for system called "system"
    - GET /redfish/v1/Systems/system0/ResetActionInfo
      Response should contain all ResetAction information for system called "system"
    - GET /redfish/v1/Systems/system1/ResetActionInfo
      Should return 404 resource not found error
    - GET /redfish/v1/Systems/foobar/ResetActionInfo
      Should return 404 resource not found error
    - GET /redfish/v1/Systems/sysem0/ResetActionInfo
      Should return 404 resource not found error

    - POST /redfish/v1/Systems/system/Actions/ComputerSystem.Reset
      Should return 200 OK
    - POST /redfish/v1/Systems/system0/Actions/ComputerSystem.Reset
      Should return 200 OK
    - POST /redfish/v1/Systems/system1/Actions/ComputerSystem.Reset
      Should return 404 resource not found error
    - POST /redfish/v1/Systems/foobar/Actions/ComputerSystem.Reset
      Should return 404 resource not found error
    - POST /redfish/v1/Systems/sysem0/Actions/ComputerSystem.Reset
      Should return 404 resource not found error
</details>

<details>
  <summary>Expected response multi host</summary>

    - GET /redfish/v1/Systems
      Response should contain all found systems and display them as
        "system0", "system1", ... "systemN"

    - GET /redfish/v1/Systems/system
      Response should contain all information for system called "system"
    - GET /redfish/v1/Systems/system0
      Response should contain all information for system called "system0"
    - GET /redfish/v1/Systems/system1
      Response should contain all information for system called "system1"
    - GET /redfish/v1/Systems/system255
      Should return 404 resource not found IF system255 does not exist
    - GET /redfish/v1/Systems/foobar
      Should return 404 resource not found error
    - GET /redfish/v1/Systems/sysem0
      Should return 404 resource not found error

    - GET /redfish/v1/Systems/system/ResetActionInfo
      Response should contain all ResetAction information for system called "system"
    - GET /redfish/v1/Systems/system0/ResetActionInfo
      Response should contain all ResetAction information for system called "system"
    - GET /redfish/v1/Systems/system1/ResetActionInfo
      Should return 404 resource not found error
    - GET /redfish/v1/Systems/foobar/ResetActionInfo
      Response should contain all ResetAction information for system called "system"
    - GET /redfish/v1/Systems/sysem0/ResetActionInfo
      Should return 404 resource not found error

    - POST /redfish/v1/Systems/system/Actions/ComputerSystem.Reset
      Should return 200 OK
    - POST /redfish/v1/Systems/system0/Actions/ComputerSystem.Reset
      Should return 200 OK
    - POST /redfish/v1/Systems/system1/Actions/ComputerSystem.Reset
      Should return 404 resource not found error
    - POST /redfish/v1/Systems/foobar/Actions/ComputerSystem.Reset
      Should return 404 resource not found error
    - POST /redfish/v1/Systems/sysem0/Actions/ComputerSystem.Reset
      Should return 404 resource not found error
</details>

### Response of local testing in QEMU

<details>
  <summary>Response single host</summary>

  GET /redfish/v1/Systems
```json
{
  "@odata.id": "/redfish/v1/Systems",
  "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system"
    }
  ],
  "Members@odata.count": 1,
  "Name": "Computer System Collection"
}
```
GET /redfish/v1/Systems/system
```json
{
  "@odata.id": "/redfish/v1/Systems/system",
  "@odata.type": "#ComputerSystem.v1_16_0.ComputerSystem",
  "Actions": {
    "#ComputerSystem.Reset": {
      "@Redfish.ActionInfo": "/redfish/v1/Systems/system/ResetActionInfo",
      "target": "/redfish/v1/Systems/system/Actions/ComputerSystem.Reset"
    }
  },
  "Bios": {
    "@odata.id": "/redfish/v1/Systems/system/Bios"
  },
  "Boot": {
    "AutomaticRetryAttempts": 3,
    "AutomaticRetryConfig": "RetryAttempts",
    "AutomaticRetryConfig@Redfish.AllowableValues": [
      "Disabled",
      "RetryAttempts"
    ],
    "BootSourceOverrideEnabled": "Disabled",
    "BootSourceOverrideMode": "UEFI",
    "BootSourceOverrideMode@Redfish.AllowableValues": [
      "Legacy",
      "UEFI"
    ],
    "BootSourceOverrideTarget": "None",
    "BootSourceOverrideTarget@Redfish.AllowableValues": [
      "None",
      "Pxe",
      "Hdd",
      "Cd",
      "Diags",
      "BiosSetup",
      "Usb"
    ],
    "RemainingAutomaticRetryAttempts": 3,
    "StopBootOnFault": "Never",
    "TrustedModuleRequiredToBoot": "Disabled"
  },
  "BootProgress": {
    "LastState": "None",
    "LastStateTime": "1970-01-01T00:00:00.000000+00:00"
  },
  "Description": "Computer System",
  "FabricAdapters": {
    "@odata.id": "/redfish/v1/Systems/system/FabricAdapters"
  },
  "GraphicalConsole": {
    "ConnectTypesSupported": [
      "KVMIP"
    ],
    "MaxConcurrentSessions": 4,
    "ServiceEnabled": true
  },
  "Id": "system",
  "IndicatorLED": "Off",
  "LastResetTime": "1970-01-01T00:00:00+00:00",
  "Links": {
    "Chassis": [
      {
        "@odata.id": "/redfish/v1/Chassis/chassis"
      }
    ],
    "ManagedBy": [
      {
        "@odata.id": "/redfish/v1/Managers/bmc"
      }
    ]
  },
  "LocationIndicatorActive": false,
  "LogServices": {
    "@odata.id": "/redfish/v1/Systems/system/LogService"
  },
  "Memory": {
    "@odata.id": "/redfish/v1/Systems/system/Memory"
  },
  "MemorySummary": {
    "TotalSystemMemoryGiB": 0.0
  },
  "Name": "system",
  "PCIeDevices": [],
  "PCIeDevices@odata.count": 0,
  "PowerRestorePolicy": "AlwaysOff",
  "PowerState": "Off",
  "ProcessorSummary": {
    "Count": 0
  },
  "Processors": {
    "@odata.id": "/redfish/v1/Systems/system/Processors"
  },
  "SerialConsole": {
    "IPMI": {
      "ServiceEnabled": true
    },
    "MaxConcurrentSessions": 15,
    "SSH": {
      "HotKeySequenceDisplay": "Press ~. to exit console",
      "Port": 2200,
      "ServiceEnabled": true
    }
  },
  "Status": {
    "Health": "OK",
    "HealthRollup": "OK",
    "State": "Disabled"
  },
  "Storage": {
    "@odata.id": "/redfish/v1/Systems/system/Storage"
  },
  "SystemType": "Physical"
}
```
GET /redfish/v1/Systems/system0
```json
{
  "@odata.id": "/redfish/v1/Systems/system",
  "@odata.type": "#ComputerSystem.v1_16_0.ComputerSystem",
  "Actions": {
    "#ComputerSystem.Reset": {
      "@Redfish.ActionInfo": "/redfish/v1/Systems/system/ResetActionInfo",
      "target": "/redfish/v1/Systems/system/Actions/ComputerSystem.Reset"
    }
  },
  "Bios": {
    "@odata.id": "/redfish/v1/Systems/system/Bios"
  },
  "Boot": {
    "AutomaticRetryAttempts": 3,
    "AutomaticRetryConfig": "RetryAttempts",
    "AutomaticRetryConfig@Redfish.AllowableValues": [
      "Disabled",
      "RetryAttempts"
    ],
    "BootSourceOverrideEnabled": "Disabled",
    "BootSourceOverrideMode": "UEFI",
    "BootSourceOverrideMode@Redfish.AllowableValues": [
      "Legacy",
      "UEFI"
    ],
    "BootSourceOverrideTarget": "None",
    "BootSourceOverrideTarget@Redfish.AllowableValues": [
      "None",
      "Pxe",
      "Hdd",
      "Cd",
      "Diags",
      "BiosSetup",
      "Usb"
    ],
    "RemainingAutomaticRetryAttempts": 3,
    "StopBootOnFault": "Never",
    "TrustedModuleRequiredToBoot": "Disabled"
  },
  "BootProgress": {
    "LastState": "None",
    "LastStateTime": "1970-01-01T00:00:00.000000+00:00"
  },
  "Description": "Computer System",
  "FabricAdapters": {
    "@odata.id": "/redfish/v1/Systems/system/FabricAdapters"
  },
  "GraphicalConsole": {
    "ConnectTypesSupported": [
      "KVMIP"
    ],
    "MaxConcurrentSessions": 4,
    "ServiceEnabled": true
  },
  "Id": "system",
  "IndicatorLED": "Off",
  "LastResetTime": "1970-01-01T00:00:00+00:00",
  "Links": {
    "Chassis": [
      {
        "@odata.id": "/redfish/v1/Chassis/chassis"
      }
    ],
    "ManagedBy": [
      {
        "@odata.id": "/redfish/v1/Managers/bmc"
      }
    ]
  },
  "LocationIndicatorActive": false,
  "LogServices": {
    "@odata.id": "/redfish/v1/Systems/system/LogService"
  },
  "Memory": {
    "@odata.id": "/redfish/v1/Systems/system/Memory"
  },
  "MemorySummary": {
    "TotalSystemMemoryGiB": 0.0
  },
  "Name": "system",
  "PCIeDevices": [],
  "PCIeDevices@odata.count": 0,
  "PowerRestorePolicy": "AlwaysOff",
  "PowerState": "Off",
  "ProcessorSummary": {
    "Count": 0
  },
  "Processors": {
    "@odata.id": "/redfish/v1/Systems/system/Processors"
  },
  "SerialConsole": {
    "IPMI": {
      "ServiceEnabled": true
    },
    "MaxConcurrentSessions": 15,
    "SSH": {
      "HotKeySequenceDisplay": "Press ~. to exit console",
      "Port": 2200,
      "ServiceEnabled": true
    }
  },
  "Status": {
    "Health": "OK",
    "HealthRollup": "OK",
    "State": "Disabled"
  },
  "Storage": {
    "@odata.id": "/redfish/v1/Systems/system/Storage"
  },
  "SystemType": "Physical"
}
```
GET /redfish/v1/Systems/system1
```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'system1' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "system1"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.16.0.ResourceNotFound",
    "message": "The requested resource of type ComputerSystem named 'system1' was not found."
  }
}
```
GET /redfish/v/fileSystems/sysem0
```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'sysem0' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "sysem0"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.16.0.ResourceNotFound",
    "message": "The requested resource of type ComputerSystem named 'sysem0' was not found."
  }
}
```
GET /redfish/v1/Systems/foobar
```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'foobar' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "foobar"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.16.0.ResourceNotFound",
    "message": "The requested resource of type ComputerSystem named 'foobar' was not found."
  }
}
```
GET /redfish/v1/Systems/system/ResetActionInfo
```json
{
  "@odata.id": "/redfish/v1/Systems/system/ResetActionInfo",
  "@odata.type": "#ActionInfo.v1_1_2.ActionInfo",
  "Id": "ResetActionInfo",
  "Name": "Reset Action Info",
  "Parameters": [
    {
      "AllowableValues": [
        "On",
        "ForceOff",
        "ForceOn",
        "ForceRestart",
        "GracefulRestart",
        "GracefulShutdown",
        "PowerCycle",
        "Nmi"
      ],
      "DataType": "String",
      "Name": "ResetType",
      "Required": true
    }
  ]
}
```
GET /redfish/v1/Systems/system0/ResetActionInfo
```json
{
  "@odata.id": "/redfish/v1/Systems/system0/ResetActionInfo",
  "@odata.type": "#ActionInfo.v1_1_2.ActionInfo",
  "Id": "ResetActionInfo",
  "Name": "Reset Action Info",
  "Parameters": [
    {
      "AllowableValues": [
        "On",
        "ForceOff",
        "ForceOn",
        "ForceRestart",
        "GracefulRestart",
        "GracefulShutdown",
        "PowerCycle",
        "Nmi"
      ],
      "DataType": "String",
      "Name": "ResetType",
      "Required": true
    }
  ]
}
```
GET /redfish/v1/Systems/system1/ResetActionInfo
```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'system1' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "system1"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.16.0.ResourceNotFound",
    "message": "The requested resource of type ComputerSystem named 'system1' was not found."
  }
}
```
GET /redfish/v1/Systems/sysem0/ResetActionInfo
```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'sysem0' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "sysem0"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.16.0.ResourceNotFound",
    "message": "The requested resource of type ComputerSystem named 'sysem0' was not found."
  }
}
```
GET /redfish/v1/Systems/foobar/ResetActionInfo
```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'foobar' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "foobar"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.16.0.ResourceNotFound",
    "message": "The requested resource of type ComputerSystem named 'foobar' was not found."
  }
}
```
POST /redfish/v1/Systems/system/Actions/ComputerSystem.Reset
```json
{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.16.0.Success",
      "MessageSeverity": "OK",
      "Resolution": "None"
    }
  ]
}
```
POST /redfish/v1/Systems/system0/Actions/ComputerSystem.Reset
```json
{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.16.0.Success",
      "MessageSeverity": "OK",
      "Resolution": "None"
    }
  ]
}
```
POST /redfish/v1/Systems/system1/Actions/ComputerSystem.Reset
```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'system1' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "system1"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      },
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The parameter GracefulRestart for the action Reset is not supported on the target resource.",
        "MessageArgs": [
          "GracefulRestart",
          "Reset"
        ],
        "MessageId": "Base.1.16.0.ActionParameterNotSupported",
        "MessageSeverity": "Warning",
        "Resolution": "Remove the parameter supplied and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.11.0.GeneralError",
    "message": "A general error has occurred. See Resolution for information on how to resolve the error."
  }
}
```
POST /redfish/v1/Systems/sysem0/Actions/ComputerSystem.Reset
```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'sysem0' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "sysem0"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      },
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The parameter GracefulRestart for the action Reset is not supported on the target resource.",
        "MessageArgs": [
          "GracefulRestart",
          "Reset"
        ],
        "MessageId": "Base.1.16.0.ActionParameterNotSupported",
        "MessageSeverity": "Warning",
        "Resolution": "Remove the parameter supplied and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.11.0.GeneralError",
    "message": "A general error has occurred. See Resolution for information on how to resolve the error."
  }
}
```
POST /redfish/v1/Systems/foobar/Actions/ComputerSystem.Reset
```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'foobar' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "foobar"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      },
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The parameter GracefulRestart for the action Reset is not supported on the target resource.",
        "MessageArgs": [
          "GracefulRestart",
          "Reset"
        ],
        "MessageId": "Base.1.16.0.ActionParameterNotSupported",
        "MessageSeverity": "Warning",
        "Resolution": "Remove the parameter supplied and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.11.0.GeneralError",
    "message": "A general error has occurred. See Resolution for information on how to resolve the error."
  }
}
```
</details>

<details>
  <summary>Response multi host</summary>
GET /redfish/v1/Systems

```json
{
  "@odata.id": "/redfish/v1/Systems",
  "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system0"
    }
  ],
  "Members@odata.count": 1,
  "Name": "Computer System Collection"
}
```
GET /redfish/v1/Systems/system

```json
{
  "@odata.id": "/redfish/v1/Systems/system0",
  "@odata.type": "#ComputerSystem.v1_16_0.ComputerSystem",
  "Actions": {
    "#ComputerSystem.Reset": {
      "@Redfish.ActionInfo": "/redfish/v1/Systems/system0/ResetActionInfo",
      "target": "/redfish/v1/Systems/system0/Actions/ComputerSystem.Reset"
    }
  },
  "Bios": {
    "@odata.id": "/redfish/v1/Systems/system0/Bios"
  },
  "Boot": {
    "AutomaticRetryAttempts": 3,
    "AutomaticRetryConfig": "RetryAttempts",
    "AutomaticRetryConfig@Redfish.AllowableValues": [
      "Disabled",
      "RetryAttempts"
    ],
    "BootSourceOverrideEnabled": "Disabled",
    "BootSourceOverrideMode": "UEFI",
    "BootSourceOverrideMode@Redfish.AllowableValues": [
      "Legacy",
      "UEFI"
    ],
    "BootSourceOverrideTarget": "None",
    "BootSourceOverrideTarget@Redfish.AllowableValues": [
      "None",
      "Pxe",
      "Hdd",
      "Cd",
      "Diags",
      "BiosSetup",
      "Usb"
    ],
    "RemainingAutomaticRetryAttempts": 3,
    "StopBootOnFault": "Never",
    "TrustedModuleRequiredToBoot": "Disabled"
  },
  "BootProgress": {
    "LastState": "None",
    "LastStateTime": "1970-01-01T00:00:00.000000+00:00"
  },
  "Description": "Computer System",
  "FabricAdapters": {
    "@odata.id": "/redfish/v1/Systems/system0/FabricAdapters"
  },
  "GraphicalConsole": {
    "ConnectTypesSupported": [
      "KVMIP"
    ],
    "MaxConcurrentSessions": 4,
    "ServiceEnabled": true
  },
  "Id": "system0",
  "IndicatorLED": "Off",
  "LastResetTime": "1970-01-01T00:00:00+00:00",
  "Links": {
    "Chassis": [
      {
        "@odata.id": "/redfish/v1/Chassis/chassis"
      }
    ],
    "ManagedBy": [
      {
        "@odata.id": "/redfish/v1/Managers/bmc"
      }
    ]
  },
  "LocationIndicatorActive": false,
  "LogServices": {
    "@odata.id": "/redfish/v1/Systems/system0/LogService"
  },
  "Memory": {
    "@odata.id": "/redfish/v1/Systems/system0/Memory"
  },
  "MemorySummary": {
    "TotalSystemMemoryGiB": 0.0
  },
  "Name": "system0",
  "PCIeDevices": [],
  "PCIeDevices@odata.count": 0,
  "PowerRestorePolicy": "AlwaysOff",
  "PowerState": "Off",
  "ProcessorSummary": {
    "Count": 0
  },
  "Processors": {
    "@odata.id": "/redfish/v1/Systems/system0/Processors"
  },
  "SerialConsole": {
    "IPMI": {
      "ServiceEnabled": true
    },
    "MaxConcurrentSessions": 15,
    "SSH": {
      "HotKeySequenceDisplay": "Press ~. to exit console",
      "Port": 2200,
      "ServiceEnabled": true
    }
  },
  "Status": {
    "Health": "OK",
    "HealthRollup": "OK",
    "State": "Disabled"
  },
  "Storage": {
    "@odata.id": "/redfish/v1/Systems/system0/Storage"
  },
  "SystemType": "Physical"
}
```
GET /redfish/v1/Systems/system0

```json
{
  "@odata.id": "/redfish/v1/Systems/system0",
  "@odata.type": "#ComputerSystem.v1_16_0.ComputerSystem",
  "Actions": {
    "#ComputerSystem.Reset": {
      "@Redfish.ActionInfo": "/redfish/v1/Systems/system0/ResetActionInfo",
      "target": "/redfish/v1/Systems/system0/Actions/ComputerSystem.Reset"
    }
  },
  "Bios": {
    "@odata.id": "/redfish/v1/Systems/system0/Bios"
  },
  "Boot": {
    "AutomaticRetryAttempts": 3,
    "AutomaticRetryConfig": "RetryAttempts",
    "AutomaticRetryConfig@Redfish.AllowableValues": [
      "Disabled",
      "RetryAttempts"
    ],
    "BootSourceOverrideEnabled": "Disabled",
    "BootSourceOverrideMode": "UEFI",
    "BootSourceOverrideMode@Redfish.AllowableValues": [
      "Legacy",
      "UEFI"
    ],
    "BootSourceOverrideTarget": "None",
    "BootSourceOverrideTarget@Redfish.AllowableValues": [
      "None",
      "Pxe",
      "Hdd",
      "Cd",
      "Diags",
      "BiosSetup",
      "Usb"
    ],
    "RemainingAutomaticRetryAttempts": 3,
    "StopBootOnFault": "Never",
    "TrustedModuleRequiredToBoot": "Disabled"
  },
  "BootProgress": {
    "LastState": "None",
    "LastStateTime": "1970-01-01T00:00:00.000000+00:00"
  },
  "Description": "Computer System",
  "FabricAdapters": {
    "@odata.id": "/redfish/v1/Systems/system0/FabricAdapters"
  },
  "GraphicalConsole": {
    "ConnectTypesSupported": [
      "KVMIP"
    ],
    "MaxConcurrentSessions": 4,
    "ServiceEnabled": true
  },
  "Id": "system0",
  "IndicatorLED": "Off",
  "LastResetTime": "1970-01-01T00:00:00+00:00",
  "Links": {
    "Chassis": [
      {
        "@odata.id": "/redfish/v1/Chassis/chassis"
      }
    ],
    "ManagedBy": [
      {
        "@odata.id": "/redfish/v1/Managers/bmc"
      }
    ]
  },
  "LocationIndicatorActive": false,
  "LogServices": {
    "@odata.id": "/redfish/v1/Systems/system0/LogService"
  },
  "Memory": {
    "@odata.id": "/redfish/v1/Systems/system0/Memory"
  },
  "MemorySummary": {
    "TotalSystemMemoryGiB": 0.0
  },
  "Name": "system0",
  "PCIeDevices": [],
  "PCIeDevices@odata.count": 0,
  "PowerRestorePolicy": "AlwaysOff",
  "PowerState": "Off",
  "ProcessorSummary": {
    "Count": 0
  },
  "Processors": {
    "@odata.id": "/redfish/v1/Systems/system0/Processors"
  },
  "SerialConsole": {
    "IPMI": {
      "ServiceEnabled": true
    },
    "MaxConcurrentSessions": 15,
    "SSH": {
      "HotKeySequenceDisplay": "Press ~. to exit console",
      "Port": 2200,
      "ServiceEnabled": true
    }
  },
  "Status": {
    "Health": "OK",
    "HealthRollup": "OK",
    "State": "Disabled"
  },
  "Storage": {
    "@odata.id": "/redfish/v1/Systems/system0/Storage"
  },
  "SystemType": "Physical"
}
```
GET /redfish/v1/Systems/system1

```json
{
  "@odata.id": "/redfish/v1/Systems/system1",
  "@odata.type": "#ComputerSystem.v1_16_0.ComputerSystem",
  "Actions": {
    "#ComputerSystem.Reset": {
      "@Redfish.ActionInfo": "/redfish/v1/Systems/system1/ResetActionInfo",
      "target": "/redfish/v1/Systems/system1/Actions/ComputerSystem.Reset"
    }
  },
  "Bios": {
    "@odata.id": "/redfish/v1/Systems/system1/Bios"
  },
  "Boot": {
    "StopBootOnFault": "Never",
    "TrustedModuleRequiredToBoot": "Disabled"
  },
  "Description": "Computer System",
  "FabricAdapters": {
    "@odata.id": "/redfish/v1/Systems/system1/FabricAdapters"
  },
  "GraphicalConsole": {
    "ConnectTypesSupported": [
      "KVMIP"
    ],
    "MaxConcurrentSessions": 4,
    "ServiceEnabled": true
  },
  "Id": "system1",
  "IndicatorLED": "Off",
  "Links": {
    "Chassis": [
      {
        "@odata.id": "/redfish/v1/Chassis/chassis"
      }
    ],
    "ManagedBy": [
      {
        "@odata.id": "/redfish/v1/Managers/bmc"
      }
    ]
  },
  "LocationIndicatorActive": false,
  "LogServices": {
    "@odata.id": "/redfish/v1/Systems/system1/LogService"
  },
  "Memory": {
    "@odata.id": "/redfish/v1/Systems/system1/Memory"
  },
  "MemorySummary": {
    "TotalSystemMemoryGiB": 0.0
  },
  "Name": "system1",
  "PCIeDevices": [],
  "PCIeDevices@odata.count": 0,
  "ProcessorSummary": {
    "Count": 0
  },
  "Processors": {
    "@odata.id": "/redfish/v1/Systems/system1/Processors"
  },
  "SerialConsole": {
    "IPMI": {
      "ServiceEnabled": true
    },
    "MaxConcurrentSessions": 15,
    "SSH": {
      "HotKeySequenceDisplay": "Press ~. to exit console",
      "Port": 2200,
      "ServiceEnabled": true
    }
  },
  "Status": {
    "Health": "OK",
    "HealthRollup": "OK",
    "State": "Enabled"
  },
  "Storage": {
    "@odata.id": "/redfish/v1/Systems/system1/Storage"
  },
  "SystemType": "Physical",
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request failed due to an internal service error.  The service is still operational.",
        "MessageArgs": [],
        "MessageId": "Base.1.16.0.InternalError",
        "MessageSeverity": "Critical",
        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
      },
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request failed due to an internal service error.  The service is still operational.",
        "MessageArgs": [],
        "MessageId": "Base.1.16.0.InternalError",
        "MessageSeverity": "Critical",
        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
      },
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request failed due to an internal service error.  The service is still operational.",
        "MessageArgs": [],
        "MessageId": "Base.1.16.0.InternalError",
        "MessageSeverity": "Critical",
        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
      }
    ],
    "code": "Base.1.11.0.GeneralError",
    "message": "A general error has occurred. See Resolution for information on how to resolve the error."
  }
}
```
GET /redfish/v/fileSystems/sysem0

```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'sysem0' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "sysem0"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.16.0.ResourceNotFound",
    "message": "The requested resource of type ComputerSystem named 'sysem0' was not found."
  }
}
```
GET /redfish/v1/Systems/foobar


```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'foobar' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "foobar"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.16.0.ResourceNotFound",
    "message": "The requested resource of type ComputerSystem named 'foobar' was not found."
  }
}```

GET /redfish/v1/Systems/system/ResetActionInfo

```json
{
  "@odata.id": "/redfish/v1/Systems/system/ResetActionInfo",
  "@odata.type": "#ActionInfo.v1_1_2.ActionInfo",
  "Id": "ResetActionInfo",
  "Name": "Reset Action Info",
  "Parameters": [
    {
      "AllowableValues": [
        "On",
        "ForceOff",
        "ForceOn",
        "ForceRestart",
        "GracefulRestart",
        "GracefulShutdown",
        "PowerCycle",
        "Nmi"
      ],
      "DataType": "String",
      "Name": "ResetType",
      "Required": true
    }
  ]
}
```
GET /redfish/v1/Systems/system0/ResetActionInfo

```json
{
  "@odata.id": "/redfish/v1/Systems/system0/ResetActionInfo",
  "@odata.type": "#ActionInfo.v1_1_2.ActionInfo",
  "Id": "ResetActionInfo",
  "Name": "Reset Action Info",
  "Parameters": [
    {
      "AllowableValues": [
        "On",
        "ForceOff",
        "ForceOn",
        "ForceRestart",
        "GracefulRestart",
        "GracefulShutdown",
        "PowerCycle",
        "Nmi"
      ],
      "DataType": "String",
      "Name": "ResetType",
      "Required": true
    }
  ]
}
```
GET /redfish/v1/Systems/system1/ResetActionInfo

```json
{
  "@odata.id": "/redfish/v1/Systems/system1/ResetActionInfo",
  "@odata.type": "#ActionInfo.v1_1_2.ActionInfo",
  "Id": "ResetActionInfo",
  "Name": "Reset Action Info",
  "Parameters": [
    {
      "AllowableValues": [
        "On",
        "ForceOff",
        "ForceOn",
        "ForceRestart",
        "GracefulRestart",
        "GracefulShutdown",
        "PowerCycle",
        "Nmi"
      ],
      "DataType": "String",
      "Name": "ResetType",
      "Required": true
    }
  ]
}
```
GET /redfish/v1/Systems/sysem0/ResetActionInfo

```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'sysem0' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "sysem0"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.16.0.ResourceNotFound",
    "message": "The requested resource of type ComputerSystem named 'sysem0' was not found."
  }
}
```
GET /redfish/v1/Systems/foobar/ResetActionInfo

```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'foobar' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "foobar"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      }
    ],
    "code": "Base.1.16.0.ResourceNotFound",
    "message": "The requested resource of type ComputerSystem named 'foobar' was not found."
  }
}
```
POST /redfish/v1/Systems/system/Actions/ComputerSystem.Reset

```json
{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.16.0.Success",
      "MessageSeverity": "OK",
      "Resolution": "None"
    }
  ]
}
```
POST /redfish/v1/Systems/system0/Actions/ComputerSystem.Reset

```json
{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.16.0.Success",
      "MessageSeverity": "OK",
      "Resolution": "None"
    }
  ]
}
```
POST /redfish/v1/Systems/system1/Actions/ComputerSystem.Reset

```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request failed due to an internal service error.  The service is still operational.",
        "MessageArgs": [],
        "MessageId": "Base.1.16.0.InternalError",
        "MessageSeverity": "Critical",
        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
      }
    ],
    "code": "Base.1.16.0.InternalError",
    "message": "The request failed due to an internal service error.  The service is still operational."
  }
}
```
POST /redfish/v1/Systems/sysem0/Actions/ComputerSystem.Reset

```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'sysem0' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "sysem0"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      },
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The parameter GracefulRestart for the action Reset is not supported on the target resource.",
        "MessageArgs": [
          "GracefulRestart",
          "Reset"
        ],
        "MessageId": "Base.1.16.0.ActionParameterNotSupported",
        "MessageSeverity": "Warning",
        "Resolution": "Remove the parameter supplied and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.11.0.GeneralError",
    "message": "A general error has occurred. See Resolution for information on how to resolve the error."
  }
}
```
POST /redfish/v1/Systems/foobar/Actions/ComputerSystem.Reset

```json
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The requested resource of type ComputerSystem named 'foobar' was not found.",
        "MessageArgs": [
          "ComputerSystem",
          "foobar"
        ],
        "MessageId": "Base.1.16.0.ResourceNotFound",
        "MessageSeverity": "Critical",
        "Resolution": "Provide a valid resource identifier and resubmit the request."
      },
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request body submitted was malformed JSON and could not be parsed by the receiving service.",
        "MessageArgs": [],
        "MessageId": "Base.1.16.0.MalformedJSON",
        "MessageSeverity": "Critical",
        "Resolution": "Ensure that the request body is valid JSON and resubmit the request."
      }
    ],
    "code": "Base.1.11.0.GeneralError",
    "message": "A general error has occurred. See Resolution for information on how to resolve the error."
  }
}
```
</details>
