### PR TITLE
Event: Change MemberId type to string

### DIFF
--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -313,7 +313,7 @@ class Subscription
         logEntryJson["Message"] = "Generated test event";
         logEntryJson["MessageId"] = "OpenBMC.0.2.TestEventLog";
         // MemberId is 0 : since we are sending one event record.
-        logEntryJson["MemberId"] = 0;
+        logEntryJson["MemberId"] = "0";
         logEntryJson["MessageArgs"] = nlohmann::json::array();
         logEntryJson["EventTimestamp"] =
             redfish::time_utils::getDateTimeOffsetNow().first;


### PR DESCRIPTION
As it's described in issue #290, the type of the MemberId according to the schema https://redfish.dmtf.org/schemas/v1/Event.v1_4_0.json is string and not int. This prevents the request from being deserialized by clients written in typed languages.

Closes #290