### PR TITLE
fix password change required response type

### DIFF
--- a/redfish-core/include/error_messages.hpp
+++ b/redfish-core/include/error_messages.hpp
@@ -1014,6 +1014,12 @@ nlohmann::json::object_t passwordChangeRequired(
 
 void passwordChangeRequired(crow::Response& res,
                             const boost::urls::url_view_base& arg1);
+/**
+ * @brief Formats PasswordChangeRequired into an `@Message.ExtendedInfo`
+ * annotation instead of the normal error response.
+ */
+void passwordChangeRequiredAnnotation(crow::Response& res,
+                                      const boost::urls::url_view_base& arg1);
 
 /**
  * @brief Formats ResetRequired message into JSON

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -227,7 +227,7 @@ inline void processAfterSessionCreation(
     asyncResp->res.result(boost::beast::http::status::created);
     if (session->isConfigureSelfOnly)
     {
-        messages::passwordChangeRequired(
+        messages::passwordChangeRequiredAnnotation(
             asyncResp->res,
             boost::urls::format("/redfish/v1/AccountService/Accounts/{}",
                                 session->username));

--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -1618,6 +1618,13 @@ nlohmann::json::object_t passwordChangeRequired(
 void passwordChangeRequired(crow::Response& res,
                             const boost::urls::url_view_base& arg1)
 {
+    res.result(boost::beast::http::status::forbidden);
+    addMessageToErrorJson(res.jsonValue, passwordChangeRequired(arg1));
+}
+
+void passwordChangeRequiredAnnotation(crow::Response& res,
+                                      const boost::urls::url_view_base& arg1)
+{
     addMessageToJsonRoot(res.jsonValue, passwordChangeRequired(arg1));
 }
 


### PR DESCRIPTION
See https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.22.1.html#password-change-required-handling

This concerns replies when a password change is required.

A request to perform a session login is supposed to respond with a [`@Message.ExtendedInfo` annotation](https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.22.1.html#extended-object-information), but otherwise succeed. This matches the current behavior.

Other requests are supposed to respond with a 403 and a proper error response, not just the ExtendedInfo annotation: https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.22.1.html#error-responses